### PR TITLE
Test with Python 3.9, stop testing Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache:
     - .pytest_cache
     - tests/testdata
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install tox-travis
   - sh get_testdata.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38,py39
 [testenv]
 deps =
   flake8


### PR DESCRIPTION
Python 3.5 is now end-of-life, Python 3.9 was released 2020-10-05