### PR TITLE
Draft: add column 438 (step time/s) to BioLogic parser

### DIFF
--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -207,6 +207,7 @@ VMPdata_colID_dtype_map = {
     431: ('|Zwe-ce|/Ohm', '<f4'),
     432: ('Re(Zwe-ce)/Ohm', '<f4'),
     433: ('-Im(Zwe-ce)/Ohm', '<f4'),
+    438: ('step time/s','<f8'),
     434: ('(Q-Qo)/C', '<f4'),
     435: ('dQ/C', '<f4'),
     441: ('<Ecv>/V', '<f4'),


### PR DESCRIPTION
This is a draft, I will add a test with example `mpr` file later.