### PR TITLE
Add ID 505 and 509 from EC-Lab

### DIFF
--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -250,6 +250,8 @@ VMPdata_colID_dtype_map = {
     500: ('step time/s', '<f8'),
     501: ('Efficiency/%', '<f8'),
     502: ('Capacity/mA.h', '<f8'),
+    505: ('Rdc/Ohm', '<f4'),
+    509: ('Acir/Dcir Control', '<u1'),
 }
 
 # These column IDs define flags which are all stored packed in a single byte


### PR DESCRIPTION
I added ID 505 and 509, assuming the Dialog for exporting to Text in EC-Lab is ordered by IDs. I have a mpr file containing those fields from a PEIS (Potential Electrochemical Impedance Spectroscopy) measurement of several batteries. 
![EC-Lab Text File Export](https://github.com/echemdata/galvani/assets/60636592/8df2a7cf-a22e-47f9-92fb-f5e1d2623be1)
