### PR TITLE
Add tox-gh based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI tests
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  # cancels running checks on new pushes
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  pytest:
+    name: Run Python unit tests
+    # Note that 20.04 is currently required until galvani supports mdbtools>=1.0.
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install MDBTools OS dependency
+        run: |
+          sudo apt install -y mdbtools
+
+      # tox-gh workflow following instructions at https://github.com/tox-dev/tox-gh
+      - name: Install tox
+        run: python -m pip install tox-gh
+
+      - name: Setup tests
+        run: |
+          tox -vv --notest
+
+      - name: Run all tests
+        run: |
+          tox --skip-pkg-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2013-2020 Christopher Kerr, "bcolsen"
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: CI tests
 on:
   pull_request:

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -426,11 +426,11 @@ class MPRfile:
             raise ValueError("Unrecognised version for data module: %d" %
                              data_module['version'])
 
-        assert(not any(remaining_headers))
+        assert not any(remaining_headers)
 
         self.dtype, self.flags_dict = VMPdata_dtype_from_colIDs(column_types)
         self.data = np.frombuffer(main_data, dtype=self.dtype)
-        assert(self.data.shape[0] == n_data_points)
+        assert self.data.shape[0] == n_data_points
 
         # No idea what these 'column types' mean or even if they are actually
         # column types at all

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2021 Christopher Kerr <chris.kerr@mykolab.ch>
 # SPDX-License-Identifier: GPL-3.0-or-later
 [tox]
-envlist = py36,py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 [testenv]
 deps =
   flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2021 Christopher Kerr <chris.kerr@mykolab.ch>
 # SPDX-License-Identifier: GPL-3.0-or-later
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310,py311
 [testenv]
 deps =
   flake8
@@ -15,3 +15,10 @@ commands =
 [flake8]
 exclude = build,dist,*.egg-info,.cache,.git,.tox,__pycache__
 max-line-length = 100
+
+[gh]
+python =
+    3.11 = py311
+    3.10 = py310
+    3.9 = py39
+    3.8 = py38


### PR DESCRIPTION
As mentioned in #89, this PR adds a GitHub Actions CI workflow, based on tox-gh, to run all tests and linters for every commit and PR to master. You can see the CI running successfully on my fork at https://github.com/ml-evs/galvani/pull/1, but this will need a maintainer to approve my workflow for first run (I think only @chatcannon?) Take it or leave it!

Caveats:

- Supporting now-deprecated version of Python <=3.7 would be a bit more work in the CI, so for now I have just disabled them in the tox config. The package will still be installable with 3.6, but remains in the untested state (at least automated testing) it is now. 
- Public GitHub repos have unlimited minutes (for now...) but not unlimited git-lfs bandwidth. Each test run seems to need to pull 12 MB in the worst case, so with the current commit activity this is probably sustainable.