### PR TITLE
add support for column 27: E_we-E_ce/V

### DIFF
--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -155,6 +155,7 @@ VMPdata_colID_dtype_map = {
     23: ('dQ/mA.h', '<f8'),  # Same as 7?
     24: ('cycle number', '<f8'),
     26: ('Rapp/Ohm', '<f4'),
+    27: ('Ewe-Ece/V', '<f4'),
     32: ('freq/Hz', '<f4'),
     33: ('|Ewe|/V', '<f4'),
     34: ('|I|/A', '<f4'),

--- a/tests/test_BioLogic.py
+++ b/tests/test_BioLogic.py
@@ -137,6 +137,7 @@ def test_parse_BioLogic_date(data, expected):
         ("C019P-0ppb-A_C01.mpr", "2019-03-14", "2019-03-14"),
         ("Rapp_Error.mpr", "2010-12-02", "2010-12-02"),
         ("Ewe_Error.mpr", "2021-11-18", "2021-11-19"),
+        ("col_27_issue_74.mpr", "2022-07-28", "2022-07-28"),
     ],
 )
 def test_MPR_dates(testdata_dir, filename, startdate, enddate):

--- a/tests/testdata/col_27_issue_74.mpr
+++ b/tests/testdata/col_27_issue_74.mpr
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b473539908334f5bdeece204db6c6ebbd5eba16bc34d75af7afcf9d05ce353bb
+size 17046


### PR DESCRIPTION
Rebased from #78 

Fix #74 