### PR TITLE
Update regular expression for mdbtools 1.0 output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
 
   pytest:
     name: Run Python unit tests
-    # Note that 20.04 is currently required until galvani supports mdbtools>=1.0.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/galvani/res2sqlite.py
+++ b/galvani/res2sqlite.py
@@ -439,7 +439,8 @@ CREATE VIEW IF NOT EXISTS Capacity_View
 def mdb_get_data_text(s3db, filename, table):
     print("Reading %s..." % table)
     insert_pattern = re.compile(
-        r'INSERT INTO "\w+" \([^)]+?\) VALUES \(("[^"]*"|[^")])+?\);\n', re.IGNORECASE
+        r"""INSERT INTO "\w+" \([^)]+?\) VALUES (\((('[^']*')|"[^"]*"|[^')])+?\),?\s*)+;\n""",
+        re.IGNORECASE,
     )
     try:
         # Initialize values to avoid NameError in except clause


### PR DESCRIPTION
The output formatting has changed - it now puts multiple data rows in a single INSERT statement, and also changes the quoting of text data.

Fixes #89