### PR TITLE
Attempt to cache LFS in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,11 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Cached LFS checkout
+        uses: nschloe/action-cached-lfs-checkout@v1.2.2
         with:
           fetch-depth: 0
-          lfs: true
+          enableCrossOsArchive: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Hopefully closes #100 by using a custom checkout action that caches LFS files for pulling within GH actions. It's a bit bizarre that GH charges so aggressively for this when the LFS is stored within their own network, but it doesn't look like this will change anytime soon (see https://github.com/actions/checkout/issues/165). Hopefully this action works well enough that we don't need to roll our own solution.