### PR TITLE
Optionally read Arbin into in-memory sqlite without temporary file

### DIFF
--- a/galvani/res2sqlite.py
+++ b/galvani/res2sqlite.py
@@ -571,12 +571,24 @@ def mdb_get_version(filename):
     return version_tuple
 
 
-def convert_arbin_to_sqlite(input_file, output_file):
+def convert_arbin_to_sqlite(input_file, output_file=None):
     """Read data from an Arbin .res data file and write to a sqlite file.
 
-    Any data currently in the sqlite file will be erased!
+    Any data currently in an sqlite file at `output_file` will be erased!
+
+    Parameters:
+        input_file (str): The path to the Arbin .res file to read from.
+        output_file (str or None): The path to the sqlite file to write to; if None,
+            return a `sqlite3.Connection` into an in-memory database.
+
+    Returns:
+        None or sqlite3.Connection
+
     """
     arbin_version = mdb_get_version(input_file)
+
+    if output_file is None:
+        output_file = ":memory:"
 
     s3db = sqlite3.connect(output_file)
 
@@ -601,6 +613,11 @@ def convert_arbin_to_sqlite(input_file, output_file):
 
     print("Vacuuming database...")
     s3db.executescript("VACUUM; ANALYZE;")
+
+    if output_file == ":memory:":
+        return s3db
+
+    s3db.close()
 
 
 def main(argv=None):

--- a/tests/test_Arbin.py
+++ b/tests/test_Arbin.py
@@ -58,14 +58,9 @@ def test_convert_Arbin_to_sqlite_function_in_memory(testdata_dir, tmpdir, basena
     """Convert an Arbin file to an in-memory SQLite database."""
     res_file = os.path.join(testdata_dir, basename + ".res")
     conn = None
-    try:
-        conn = res2sqlite.convert_arbin_to_sqlite(res_file)
-        assert conn is not None
+    with res2sqlite.convert_arbin_to_sqlite(res_file) as conn:
         csr = conn.execute("SELECT * FROM Channel_Normal_Table;")
         csr.fetchone()
-    finally:
-        if conn is not None:
-            conn.close()
 
 
 @pytest.mark.skipif(

--- a/tests/test_Arbin.py
+++ b/tests/test_Arbin.py
@@ -53,6 +53,21 @@ def test_convert_Arbin_to_sqlite_function(testdata_dir, tmpdir, basename):
         csr.fetchone()
 
 
+@pytest.mark.parametrize("basename", ["arbin1", "UM34_Test005E"])
+def test_convert_Arbin_to_sqlite_function_in_memory(testdata_dir, tmpdir, basename):
+    """Convert an Arbin file to an in-memory SQLite database."""
+    res_file = os.path.join(testdata_dir, basename + ".res")
+    conn = None
+    try:
+        conn = res2sqlite.convert_arbin_to_sqlite(res_file)
+        assert conn is not None
+        csr = conn.execute("SELECT * FROM Channel_Normal_Table;")
+        csr.fetchone()
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 @pytest.mark.skipif(
     not have_mdbtools, reason="Reading the Arbin file requires MDBTools"
 )


### PR DESCRIPTION
Closes #104.

Changes the `convert_arbin_to_sqlite` function to allow `output_file` to be None, in which case an in-memory database is used (or equivalently if `:memory:` is explicitly passed).

I've also tried to make sure that the sqlite database is properly closed when the function completes (which was never a big deal for the command-line version but is useful when using the functional interface directly).