### PR TITLE
Add `Analog IN <n>/V` columns to map

### DIFF
--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -276,7 +276,7 @@ VMPdata_colID_dtype_map = {
     11: ("<I>/mA", "<f8"),
     13: ("(Q-Qo)/mA.h", "<f8"),
     16: ("Analog IN 1/V", "<f4"),
-    17: ("Analog IN 1/V", "<f4"),  # Unclear if this column is duplicated in the underlying data
+    17: ("Analog IN 2/V", "<f4"),  # Probably column 18 is Analog IN 3/V, if anyone hits this error in the future
     19: ("control/V", "<f4"),
     20: ("control/mA", "<f4"),
     23: ("dQ/mA.h", "<f8"),  # Same as 7?

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -276,6 +276,7 @@ VMPdata_colID_dtype_map = {
     11: ("<I>/mA", "<f8"),
     13: ("(Q-Qo)/mA.h", "<f8"),
     16: ("Analog IN 1/V", "<f4"),
+    17: ("Analog IN 1/V", "<f4"),  # Unclear if this column is duplicated in the underlying data
     19: ("control/V", "<f4"),
     20: ("control/mA", "<f4"),
     23: ("dQ/mA.h", "<f8"),  # Same as 7?


### PR DESCRIPTION
Closes #106.

After checking in ECLab, the missing column is indeed `Analog IN 2/V`. I wonder if the next one should also be `Analog IN 3/V`, but probably we should not make assumptions... 