### PR TITLE
LFS workaround using archived releases in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,30 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - name: Cached LFS checkout
-        uses: nschloe/action-cached-lfs-checkout@v1.2.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          enableCrossOsArchive: true
+          lfs: false
+
+      # Due to limited LFS bandwidth, it is preferable to download
+      # test files from the last release.
+      #
+      # This does mean that testing new LFS files in the CI is tricky;
+      # care should be taken to also test new files locally first
+      # Tests missing these files in the CI should still fail.
+      - name: Download static files from last release for testing
+        uses: robinraju/release-downloader@v1
+        with:
+          latest: true
+          tarBall: false
+          fileName: "galvani-*.gz"
+          zipBall: false
+          out-file-path: /home/runner/work/last-release
+          extract: true
+
+      - name: Copy test files from static downloaded release
+        run: |
+          cp -r /home/runner/work/last-release/*/tests/testdata tests
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -50,5 +69,5 @@ jobs:
           tox -vv --notest
 
       - name: Run all tests
-        run: |
+        run: |-
           tox --skip-pkg-install

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 Read proprietary file formats from electrochemical test stations.
 
+> [!WARNING]
+> A note about test files and Git LFS:
+>
+> This project uses Git Large File Storage (LFS) to store its test files,
+> however the LFS quota provided by GitHub is frequently exceeded. 
+> This means that anyone cloning the repository with LFS installed will get
+> failures unless they set the `GIT_LFS_SKIP_SMUDGE=1` environment variable when
+> cloning. 
+> The full test data from the last release can always be obtained by
+> downloading the GitHub release archives (tar or zip), at
+> https://github.com/echemdata/galvani/releases/latest
+>
+> If you wish to add test files, please ensure they are as small as possible,
+> and take care that your tests work locally without the need for the LFS files.
+> Ideally, you could commit them to your fork when making a PR, and then they
+> can be converted to LFS files as part of the review.
+
 # Usage
 
 ## Bio-Logic .mpr files

--- a/README.md
+++ b/README.md
@@ -9,23 +9,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 Read proprietary file formats from electrochemical test stations.
 
-> [!WARNING]
-> A note about test files and Git LFS:
->
-> This project uses Git Large File Storage (LFS) to store its test files,
-> however the LFS quota provided by GitHub is frequently exceeded. 
-> This means that anyone cloning the repository with LFS installed will get
-> failures unless they set the `GIT_LFS_SKIP_SMUDGE=1` environment variable when
-> cloning. 
-> The full test data from the last release can always be obtained by
-> downloading the GitHub release archives (tar or zip), at
-> https://github.com/echemdata/galvani/releases/latest
->
-> If you wish to add test files, please ensure they are as small as possible,
-> and take care that your tests work locally without the need for the LFS files.
-> Ideally, you could commit them to your fork when making a PR, and then they
-> can be converted to LFS files as part of the review.
-
 # Usage
 
 ## Bio-Logic .mpr files
@@ -64,13 +47,29 @@ The latest galvani releases can be installed from [PyPI](https://pypi.org/projec
 pip install galvani
 ```
 
-The latest development version can be installed with `pip` directly from GitHub:
+The latest development version can be installed with `pip` directly from GitHub (see note about git-lfs below):
 
 ```shell
-pip install git+https://github.com/echemdata/galvani
+GIT_LFS_SKIP_SMUDGE=1 pip install git+https://github.com/echemdata/galvani
 ```
 
 ## Development installation and contributing 
+
+> [!WARNING]
+> 
+> This project uses Git Large File Storage (LFS) to store its test files,
+> however the LFS quota provided by GitHub is frequently exceeded. 
+> This means that anyone cloning the repository with LFS installed will get
+> failures unless they set the `GIT_LFS_SKIP_SMUDGE=1` environment variable when
+> cloning. 
+> The full test data from the last release can always be obtained by
+> downloading the GitHub release archives (tar or zip), at
+> https://github.com/echemdata/galvani/releases/latest
+>
+> If you wish to add test files, please ensure they are as small as possible,
+> and take care that your tests work locally without the need for the LFS files.
+> Ideally, you could commit them to your fork when making a PR, and then they
+> can be converted to LFS files as part of the review.
 
 If you wish to contribute to galvani, please clone the repository and install the testing dependencies:
 

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -276,7 +276,7 @@ VMPdata_colID_dtype_map = {
     11: ("<I>/mA", "<f8"),
     13: ("(Q-Qo)/mA.h", "<f8"),
     16: ("Analog IN 1/V", "<f4"),
-    17: ("Analog IN 2/V", "<f4"),  # Probably column 18 is Analog IN 3/V, if anyone hits this error in the future
+    17: ("Analog IN 2/V", "<f4"),  # Probably column 18 is Analog IN 3/V, if anyone hits this error in the future  # noqa: E501
     19: ("control/V", "<f4"),
     20: ("control/mA", "<f4"),
     23: ("dQ/mA.h", "<f8"),  # Same as 7?


### PR DESCRIPTION
This PR attempts to workaround LFS billing limitations by using the latest released tests files in the CI, rather than pulling them from LFS. This will make adding new files a bit more awkward (see README note), but should at least allow our existing tests to run.