### PR TITLE
Pin and update release downloader action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,10 @@ jobs:
       # care should be taken to also test new files locally first
       # Tests missing these files in the CI should still fail.
       - name: Download static files from last release for testing
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@v1.12
         with:
           latest: true
-          tarBall: false
-          fileName: "galvani-*.gz"
-          zipBall: false
+          tarBall: true
           out-file-path: /home/runner/work/last-release
           extract: true
 


### PR DESCRIPTION
In the last release of the release-downloader action, they moved the v1 tag to point at their latest v1.x release, which has a slightly different API. This PR fixes the release downloader so that the LFS files can still be accessed from the CI.