### PR TITLE
Add mode for handling unknown columns in MPR files

### DIFF
--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -316,6 +316,7 @@ VMPdata_colID_dtype_map = {
     174: ("<Ewe>/V", "<f4"),
     178: ("(Q-Qo)/C", "<f4"),
     179: ("dQ/C", "<f4"),
+    182: ("step time/s", "<f8"),
     211: ("Q charge/discharge/mA.h", "<f8"),
     212: ("half cycle", "<u4"),
     213: ("z cycle", "<u4"),

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -633,7 +633,10 @@ class MPRfile:
                 if col.startswith("unknown_colID"):
                     unknown_cols.append(col)
             if len(unknown_cols) > 3:
-                raise RuntimeError("Too many unknown columns to attempt to read combinatorially: %s" % unknown_cols)
+                raise RuntimeError(
+                    "Too many unknown columns to attempt to read combinatorially: %s"
+                    % unknown_cols
+                )
 
         if unknown_cols:
             # create a list of all possible combinations of dtypes
@@ -653,7 +656,11 @@ class MPRfile:
                 except ValueError:
                     continue
             else:
-                raise RuntimeError("Unable to read data for unknown columns %s with any of the common dtypes %s", unknown_cols, UNKNOWN_COLUMN_TYPE_HIERARCHY)
+                raise RuntimeError(
+                    "Unable to read data for unknown columns %s with any of the common dtypes %s",
+                    unknown_cols,
+                    UNKNOWN_COLUMN_TYPE_HIERARCHY
+                )
 
         else:
             self.dtype = np.dtype(dtypes)

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -632,6 +632,8 @@ class MPRfile:
             for col, _ in dtypes:
                 if col.startswith("unknown_colID"):
                     unknown_cols.append(col)
+            if len(unknown_cols) > 3:
+                raise RuntimeError("Too many unknown columns to attempt to read combinatorially: %s" % unknown_cols)
 
         if unknown_cols:
             # create a list of all possible combinations of dtypes

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -431,7 +431,7 @@ def parse_BioLogic_date(date_text):
     return date(tm.tm_year, tm.tm_mon, tm.tm_mday)
 
 
-def VMPdata_dtype_from_colIDs(colIDs, error_on_unknown_column: bool = True):
+def VMPdata_dtype_from_colIDs(colIDs, error_on_unknown_column: bool = False):
     """Get a numpy record type from a list of column ID numbers.
 
     The binary layout of the data in the MPR file is described by the sequence

--- a/galvani/BioLogic.py
+++ b/galvani/BioLogic.py
@@ -431,7 +431,7 @@ def parse_BioLogic_date(date_text):
     return date(tm.tm_year, tm.tm_mon, tm.tm_mday)
 
 
-def VMPdata_dtype_from_colIDs(colIDs, error_on_unknown_column: bool = False):
+def VMPdata_dtype_from_colIDs(colIDs, error_on_unknown_column: bool = True):
     """Get a numpy record type from a list of column ID numbers.
 
     The binary layout of the data in the MPR file is described by the sequence

--- a/tests/test_BioLogic.py
+++ b/tests/test_BioLogic.py
@@ -99,7 +99,7 @@ def test_colID_to_dtype(colIDs, expected):
         return
     expected_dtype = np.dtype(expected)
     dtype, flags_dict = BioLogic.VMPdata_dtype_from_colIDs(colIDs)
-    assert dtype == expected_dtype
+    assert np.dtype(dtype) == expected_dtype
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR provides a workaround for several open issues regarding unknown columns. The main reason this has been more prevalent recently seems to be that EC-lab adds extra columns to data files when opening and saving, even if these columns were not necessarily recorded directly by an instrument.

This does not remove the need to handling such columns properly, but should allow other known columns to be read successfully.

This PR adds a `error_on_unknown_column` option to `MPRfile` (true by default, the current behaviour), which if false, will collect unknown columns and attempt to read the file with all possible combinations of common dtypes, until successful. This approach will not scale very well to cases with many unknown columns, but works well for one, two or three unknown columns (there is a guard preventing it from this exponential wall of possible combinations). These columns will still have unknown names in the output, but the remaining data can be used.

As a side effect, the `VMPdata_dtype_from_colIDs` method now returns an intermediate generic representation that can be easily edited, rather than the hardcoded `np.dtype`. It then needs to be converted before being used to read the buffer.

This PR also adds col 182 as step time/s `<f8`, as suggested by @AShnier in https://github.com/echemdata/galvani/issues/112#issuecomment-2710554095 (I finally have a file where I can confirm it directly).